### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash -euxo pipefail {0}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash -euxo pipefail {0}
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
 
       - name: Install dependencies
         run: |
@@ -52,7 +52,7 @@ jobs:
           cp nginx-1.21.3/objs/ngx_http_cbor_resp_ic_module.so debpkg-cbor-resp-ic/usr/lib/nginx/modules/
 
       - name: Create deb for ndk
-        uses: jiro4989/build-deb-action@v2
+        uses: jiro4989/build-deb-action@d38d2efb9670d446ad836cc638d9fe871524af6b # v2.8.1
         with:
           package: libnginx-mod-http-ndk
           package_root: debpkg-ndk
@@ -63,7 +63,7 @@ jobs:
           desc: "Nginx development kit (NDK)"
 
       - name: Create deb for cbor-input
-        uses: jiro4989/build-deb-action@v2
+        uses: jiro4989/build-deb-action@d38d2efb9670d446ad836cc638d9fe871524af6b # v2.8.1
         with:
           package: libnginx-mod-http-cbor-input
           package_root: debpkg-cbor-input
@@ -74,7 +74,7 @@ jobs:
           desc: "Nginx module for decoding CBOR input"
 
       - name: Create deb for cbor-req-ic
-        uses: jiro4989/build-deb-action@v2
+        uses: jiro4989/build-deb-action@d38d2efb9670d446ad836cc638d9fe871524af6b # v2.8.1
         with:
           package: libnginx-mod-http-cbor-req-ic
           package_root: debpkg-cbor-req-ic
@@ -85,7 +85,7 @@ jobs:
           desc: "Nginx module for decoding IC CBOR requests"
 
       - name: Create deb for cbor-resp-ic
-        uses: jiro4989/build-deb-action@v2
+        uses: jiro4989/build-deb-action@d38d2efb9670d446ad836cc638d9fe871524af6b # v2.8.1
         with:
           package: libnginx-mod-http-cbor-resp-ic
           package_root: debpkg-cbor-resp-ic
@@ -96,7 +96,7 @@ jobs:
           desc: "Nginx module for decoding IC CBOR responses"
 
       - name: Upload debs to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ./*.deb


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@master` -> `actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master`
  - Version: master | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/61b9e3751b92087fd0b06925ba6dd6314e06f089

- `jiro4989/build-deb-action@v2` -> `jiro4989/build-deb-action@d38d2efb9670d446ad836cc638d9fe871524af6b # v2.8.1`
  - Version: v2.8.1 | Latest: v4.3.0 | Release age: 234d
  - Commit: https://github.com/jiro4989/build-deb-action/commit/d38d2efb9670d446ad836cc638d9fe871524af6b

- `svenstaro/upload-release-action@v2` -> `svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5`
  - Version: 2.11.5 | Latest: 2.11.5 | Release age: 22d
  - Commit: https://github.com/svenstaro/upload-release-action/commit/29e53e917877a24fad85510ded594ab3c9ca12de


### Files modified

- `.github/workflows/build.yml`
- `.github/workflows/release.yml`